### PR TITLE
Updates from May commissioning

### DIFF
--- a/lib/beamformer/src/cublas_beamformer.cu
+++ b/lib/beamformer/src/cublas_beamformer.cu
@@ -516,3 +516,41 @@ void run_beamformer(signed char * data_in, float * data_out) {
 	// cudaFree(d_data);
 	// cudaFree(d_outputs);
 }
+
+
+void rtbfCleanup() {
+	// Free up GPU memory at the end of a program
+	if (d_beamformed != NULL) {
+		cudaFree(d_beamformed);
+	}
+
+	if (d_data != NULL) {
+		cudaFree(d_data);
+	}
+
+	if (d_data1 != NULL) {
+		cudaFree(d_data1);
+	}
+
+	if (d_outputs != NULL) {
+		cudaFree(d_outputs);
+	}
+
+	if (d_weights != NULL) {
+		cudaFree(d_weights);
+	}
+
+	if (d_arr_A != NULL) {
+		cudaFree(d_arr_A);
+	}
+
+	if (d_arr_B != NULL) {
+		cudaFree(d_arr_B);
+	}
+
+	if (d_arr_C != NULL) {
+		cudaFree(d_arr_C);
+	}
+	// Free up and release cublas handle
+	cublasDestroy(handle);
+}

--- a/lib/beamformer/src/cublas_beamformer.h
+++ b/lib/beamformer/src/cublas_beamformer.h
@@ -38,6 +38,7 @@ void bf_get_weight_filename(char * weight_filename);
 long long unsigned int bf_get_xid();
 void update_weights(char * filename);
 void init_beamformer();
+void rtbfCleanup(); 
 void run_beamformer(signed char * data_in, float * data_out);
 #ifdef __cplusplus
 }

--- a/lib/hashpipe/src/hashpipe_databuf.c
+++ b/lib/hashpipe/src/hashpipe_databuf.c
@@ -155,8 +155,6 @@ void hashpipe_databuf_clear(hashpipe_databuf_t *d)
     memset(arg.array, 0, sizeof(unsigned short)*d->n_block);
     semctl(d->semid, 0, SETALL, arg);
     free(arg.array);
-
-    // TODO memset to 0?
 }
 
 char *hashpipe_databuf_data(hashpipe_databuf_t *d, int block_id)

--- a/lib/hashpipe/src/hashpipe_databuf.h
+++ b/lib/hashpipe/src/hashpipe_databuf.h
@@ -49,7 +49,6 @@ hashpipe_databuf_t *hashpipe_databuf_attach(int instance_id, int databuf_id);
 int hashpipe_databuf_detach(hashpipe_databuf_t *d);
 
 /* Set all semaphores to 0, 
- * TODO: memset to 0 as well?
  */
 void hashpipe_databuf_clear(hashpipe_databuf_t *d);
 

--- a/lib/pfb/src/pfb.cu
+++ b/lib/pfb/src/pfb.cu
@@ -81,7 +81,7 @@ int runPFB(signed char* inputData_h, float* outputData_h, params pfbParams) {
 		CUDASafeCallWithCleanUp(cudaGetLastError());
 	}
 
-	float2* fftOutPtr = g_pf2FFTOut_d;
+	//float2* fftOutPtr = g_pf2FFTOut_d;
 	while(!g_IsProcDone) {
 		//FFT
 		iRet = doFFT();
@@ -116,7 +116,9 @@ int runPFB(signed char* inputData_h, float* outputData_h, params pfbParams) {
 	g_pf2FFTIn_d = g_pf2FFTIn_d -countFFT*g_iNumSubBands*g_iNFFT;
 
 	int outDataSize = countFFT * g_iNumSubBands * g_iNFFT;
-	CUDASafeCallWithCleanUp(cudaMemcpy(outputData_h, fftOutPtr, outDataSize*sizeof(cufftComplex), cudaMemcpyDeviceToHost));
+	//CUDASafeCallWithCleanUp(cudaMemcpy(outputData_h, fftOutPtr, outDataSize*sizeof(cufftComplex), cudaMemcpyDeviceToHost));
+	//printf("making sure new build...\n");
+	CUDASafeCallWithCleanUp(cudaMemcpy(outputData_h, g_pf2FFTOut_d, outDataSize*sizeof(cufftComplex), cudaMemcpyDeviceToHost));
 
 	return iRet;
 

--- a/src/flag_beamsave_thread.c
+++ b/src/flag_beamsave_thread.c
@@ -71,8 +71,9 @@ static void * run(hashpipe_thread_args_t * args) {
         hashpipe_status_unlock_safe(&st);
 
         char filename[256];
-        sprintf(filename, "%s/TGBT16A_508_01/TMP/BF/beamformer_%s_mcnt_%lld.out", data_dir, BANK, (long long)start_mcnt);
-        fprintf(stderr, "Saving to %s\n", filename);
+        //sprintf(filename, "%s/TGBT16A_508_01/TMP/BF/beamformer_%s_mcnt_%lld.out", data_dir, BANK, (long long)start_mcnt);
+        //fprintf(stderr, "Saving to %s\n", filename);
+        printf("RTBF: mcnt: %lld\n", (long long)start_mcnt);
         if (SAVE) {
             float * p = (float *)db_in->block[curblock_in].data;
             FILE * filePtr = fopen(filename, "w");

--- a/src/flag_databuf.h
+++ b/src/flag_databuf.h
@@ -158,7 +158,7 @@ typedef uint8_t hashpipe_databuf_cache_alignment[
  * It is the output buffer of the flag_net_thread.
  * It is the input buffer of the flag_transpose_thread.
  */
-#define N_INPUT_BLOCKS 4
+#define N_INPUT_BLOCKS 100
 
 // A typedef for a block header
 typedef struct flag_input_header {

--- a/src/flag_databuf.h
+++ b/src/flag_databuf.h
@@ -143,8 +143,11 @@
 // Macros specific to the fine-channel correlator (PFB correlator)
 #define N_TIME_PER_PFB_BLOCK XGPU_PFB_NTIME
 #define N_CHAN_PER_PFB_BLOCK XGPU_PFB_NFREQUENCY
+#define N_CHAN_PFB_SELECTED 5
 #define N_PFB_COR_MATRIX (N_INPUTS/2*(N_INPUTS/2 + 1)/2*N_CHAN_PER_PFB_BLOCK*4)
 #define N_BYTES_PER_PFB_BLOCK (N_TIME_PER_BLOCK * N_CHAN_PER_PFB_BLOCK * N_INPUTS * N_BITS_IQ * 2 / 8)
+
+#define flag_pfb_gpu_input_databuf_idx(m,f,t,c) ((2*N_INPUTS_PER_FENGINE/sizeof(uint64_t))*(f+Nf*(c+N_CHAN_PFB_SELECTED*(t+Nt*m))))
 
 // Macros to maintain cache alignment
 #define CACHE_ALIGNMENT (128)
@@ -159,7 +162,7 @@ typedef uint8_t hashpipe_databuf_cache_alignment[
  * It is the input buffer of the flag_transpose_thread.
  */
 
-#define N_INPUT_BLOCKS 105
+#define N_INPUT_BLOCKS 100
 
 // A typedef for a block header
 typedef struct flag_input_header {

--- a/src/flag_net_thread.c
+++ b/src/flag_net_thread.c
@@ -232,7 +232,7 @@ static void set_block_filled(flag_input_databuf_t * db, block_info_t * binfo) {
 // (2) block population (output buffer data type is a block)
 // (3) buffer population (if block is filled)
 static inline int64_t process_packet(flag_input_databuf_t * db, struct hashpipe_udp_packet *p) {
-    packet_header_t     pkt_header;
+    packet_header_t pkt_header;
 
     // Initialize block information data types
     if (!binfo.initialized) {
@@ -407,7 +407,7 @@ static void *run(hashpipe_thread_args_t * args) {
     hashpipe_status_unlock_safe(&st);
 
     struct hashpipe_udp_packet p;
-    struct hashpipe_udp_packet bh; // blackhole packet to suck up data that isnt processed
+    //struct hashpipe_udp_packet bh; // blackhole packet to suck up data that isnt processed
 
     /* Give all the threads a chance to start before opening network socket */
     /*
@@ -537,13 +537,11 @@ static void *run(hashpipe_thread_args_t * args) {
         if (cur_state == IDLE) {
             // cmd = check_cmd(gpu_fifo_id);
              
-	    // keep receiving packets but send them to a blackhole packet, these wont be processed
-	    
-            bh.packet_size = recv(up.sock, bh.data, HASHPIPE_MAX_PACKET_SIZE, 0);
-	    if(bh.packet_size != -1) {
-		//printf("blackhole!!!\n");
-	    }
-
+	        // keep receiving packets but send them to a blackhole packet, these wont be processed
+            //bh.packet_size = recv(up.sock, bh.data, HASHPIPE_MAX_PACKET_SIZE, 0);
+    	    //if(bh.packet_size != -1) {
+    		//printf("blackhole!!!\n");
+    	    //}
 
             // If command is START, proceed to ACQUIRE state
             if (master_cmd == START) {
@@ -604,7 +602,7 @@ static void *run(hashpipe_thread_args_t * args) {
                 int cleanA = 1;
                 int cleanB = 1;
                 int cleanC = 1;
-		printf("NET: CLEANUP condition met!\n");
+		        printf("NET: CLEANUP condition met!\n");
                 sleep(1);
                 printf("NET: Informing other threads of cleanup condition\n");
                 while (cleanA != 0 && cleanB != 0 && cleanC != 0) {
@@ -688,8 +686,8 @@ static void *run(hashpipe_thread_args_t * args) {
     }
 
     pthread_cleanup_pop(1); /* Closes push(hashpipe_udp_close) */
-
     hashpipe_status_lock_busywait_safe(&st);
+    printf("NET: Exiting thread loop...\n");
     hputs(st.buf, status_key, "terminated");
     hashpipe_status_unlock_safe(&st);
     return NULL;

--- a/src/flag_net_thread.c
+++ b/src/flag_net_thread.c
@@ -398,6 +398,7 @@ static void *run(hashpipe_thread_args_t * args) {
     hashpipe_status_unlock_safe(&st);
 
     struct hashpipe_udp_packet p;
+    struct hashpipe_udp_packet bh; // blackhole packet to suck up data that isnt processed
 
     /* Give all the threads a chance to start before opening network socket */
     /*
@@ -505,7 +506,14 @@ static void *run(hashpipe_thread_args_t * args) {
          ************************************************************/
         // If in IDLE state, look for START command
         if (cur_state == IDLE) {
-             // cmd = check_cmd(gpu_fifo_id);
+            // cmd = check_cmd(gpu_fifo_id);
+             
+	    // keep receiving packets but send them to a blackhole packet, these wont be processed
+	    
+            bh.packet_size = recv(up.sock, bh.data, HASHPIPE_MAX_PACKET_SIZE, 0);
+	    if(bh.packet_size != -1) {
+		//printf("blackhole!!!\n");
+	    }
 
 
             // If command is START, proceed to ACQUIRE state

--- a/src/flag_transpose_thread.c
+++ b/src/flag_transpose_thread.c
@@ -57,7 +57,7 @@ static void * run(hashpipe_thread_args_t * args) {
         if (cur_state == ACQUIRE) {
             next_state = ACQUIRE;
             // Wait for input buffer block to be filled
-            while ((rv=flag_input_databuf_wait_filled(db_in, curblock_in)) != HASHPIPE_OK) {
+            while ((rv=flag_input_databuf_wait_filled(db_in, curblock_in)) != HASHPIPE_OK && run_threads()) {
                 if (rv==HASHPIPE_TIMEOUT) { // If we are waiting for an input block...
                     // Check to see if network thread is in cleanup
                     hashpipe_status_lock_safe(&st);
@@ -76,12 +76,13 @@ static void * run(hashpipe_thread_args_t * args) {
                     break;
                 }
             }
+            if (!run_threads()) break;
 
             //printf("TRA: Rx %lld, curblock_in %d\n", (long long int)db_in->block[curblock_in].header.mcnt_start, curblock_in);
             if (next_state != CLEANUP) {
 
                 // Wait for output buffer block to be freed
-                while ((rv=flag_gpu_input_databuf_wait_free(db_out, curblock_out)) != HASHPIPE_OK) {
+                while ((rv=flag_gpu_input_databuf_wait_free(db_out, curblock_out)) != HASHPIPE_OK && run_threads()) {
                     if (rv == HASHPIPE_TIMEOUT) {
                         //hashpipe_status_lock_safe(&st);
                         //hputs(st.buf, status_key, "waiting for free block");
@@ -94,7 +95,8 @@ static void * run(hashpipe_thread_args_t * args) {
                         break;
                     }
                 }
-       
+                if (!run_threads());
+
                 // Print out the header information for this block 
                 flag_input_header_t tmp_header;
                 memcpy(&tmp_header, &db_in->block[curblock_in].header, sizeof(flag_input_header_t));
@@ -107,6 +109,10 @@ static void * run(hashpipe_thread_args_t * args) {
                 /**********************************************
                  * Perform transpose
                  **********************************************/
+
+                // clock_t start, end;
+                // start = clock();
+
                 int m; int f;
                 int t; int c;
                 uint64_t * in_p;
@@ -125,6 +131,10 @@ static void * run(hashpipe_thread_args_t * args) {
                     }
                 }
 
+                // end = clock();
+                // double timeTaken = 0;
+                // timeTaken = ((double) (end - start))/CLOCKS_PER_SEC;
+                // printf("TRA: %fs\n", timeTaken);
                 /***********************************************
                  * Add header information to output block
                  ***********************************************/
@@ -169,6 +179,10 @@ static void * run(hashpipe_thread_args_t * args) {
     }
 
     // Thread terminates after loop
+    hashpipe_status_lock_busywait_safe(&st);
+    printf("TRA: Exiting loop...\n");
+    hputs(st.buf, status_key, "terminated");
+    hashpipe_status_unlock_safe(&st);
     return NULL;
 }
 

--- a/utils/correlator1_interpreter/interp_data.m
+++ b/utils/correlator1_interpreter/interp_data.m
@@ -38,7 +38,7 @@ for i = 1:Nele_tot/2
 end
 
 Rtot = zeros(Nele_tot, Nele_tot, Nbin);
-PATH = '/home/mburnett/dibas/lib/python/';
+PATH = '/users/mburnett/FLAG/dibas/lib/python/';
 mcnt = [0]%, 200, 400, 600];
 %for mcnt = 0:2:198
 for k = 1:length(mcnt)
@@ -68,7 +68,7 @@ for k = 1:length(mcnt)
         Rb = Rb./Nsamp;
 
         Rtot(:,:,Nb) = Rtot(:,:,Nb) + Rb.*Nsamp;
-
+              
         fig_mod = ceil(Nb/40);
         fig_mod_plot = mod(Nb,40);
         figure(fig_mod);

--- a/utils/correlator1_interpreter/interp_data.m
+++ b/utils/correlator1_interpreter/interp_data.m
@@ -38,7 +38,7 @@ for i = 1:Nele_tot/2
 end
 
 Rtot = zeros(Nele_tot, Nele_tot, Nbin);
-PATH = '/users/mburnett/FLAG/dibas/lib/python/';
+PATH = '/lustre/projects/flag/';
 mcnt = [0]%, 200, 400, 600];
 %for mcnt = 0:2:198
 for k = 1:length(mcnt)

--- a/utils/pkt_gen/packet_gen.m
+++ b/utils/pkt_gen/packet_gen.m
@@ -159,7 +159,7 @@ for xid = 1:Nxengines
     remoteHost = ['10.10.1.', num2str(xid)];
 
     if xid == 1
-        remoteHost = '10.17.16.208';
+        remoteHost = '10.17.16.200';
     end
     %if xid == 14
     %    remoteHost = '10.10.1.1';
@@ -173,8 +173,8 @@ end
 % Generate packet payloads
 mcnt = 0; % Each mcnt represents 20 packets across all F-engines in the
           % same time frame
-  
-for mcnt = [0:201, 400:50:20000] %while mcnt <= 10000
+  %0:201
+for mcnt = [0:401] %while mcnt <= 10000
     disp(['Sending mcnt = ', num2str(mcnt)]);
     for xid = 1:1 % Set to a single X-engine for single HPC testing (Richard B.)
         for fid = 1:Nfengines

--- a/utils/pkt_gen/packet_gen.m
+++ b/utils/pkt_gen/packet_gen.m
@@ -155,10 +155,10 @@ CEN_imag = int8(((imag(CEN) - c_min)/(c_max - c_min) - 0.5) * 256);
 
 % Create UDP sockets - 1 IP address per Xengine (xid)
 for xid = 1:Nxengines
-    remoteHost = ['10.10.1.', num2str(xid)];
-    %if xid == 1
-    %    remoteHost = '10.10.1.14';
-    %end
+    %remoteHost = ['10.10.1.', num2str(xid)];
+    if xid == 1
+        remoteHost = '10.17.16.208';
+    end
     %if xid == 14
     %    remoteHost = '10.10.1.1';
     %end
@@ -174,7 +174,7 @@ mcnt = 0; % Each mcnt represents 20 packets across all F-engines in the
   
 for mcnt = [0:201, 400:50:20000] %while mcnt <= 10000
     disp(['Sending mcnt = ', num2str(mcnt)]);
-    for xid = 13:13 % Set to a single X-engine for single HPC testing (Richard B.)
+    for xid = 1:1 % Set to a single X-engine for single HPC testing (Richard B.)
         for fid = 1:Nfengines
             w_idx = 1;
             


### PR DESCRIPTION
These commits are improvements made while out for the May commissioning.

Hashpipe -- Children processes were terminated by parent without reclaiming resources. Hashpipe now waits for the child to indicate that it has cleaned up and joined using pthread().

GPU codes -- included methods in xgpu and the beamformer that can be called to clean up gpu memory.

net_thread -- while loops and timeout fixes / new window buffer
PFB HI observation mode. The pfb_transpose_thread was indexing out of memory.

Other fixes.

