### PR TITLE
Mid July/Aug Commissioning Improvements

### DIFF
--- a/lib/beamformer/src/cublas_beamformer.cu
+++ b/lib/beamformer/src/cublas_beamformer.cu
@@ -15,81 +15,17 @@
 
 using namespace std;
 
-// CUDA-specific function prototypes
-void print_matrix(const cuComplex *A, int nr_rows_A, int nr_cols_A, int nr_sheets_A);
+void beamform();
 
-void print_matrix2(const float *A, int nr_rows_A, int nr_cols_A);
-
-void GPU_fill(cuComplex *A, int nr_rows_A, int nr_cols_A);
-
-void GPU_fill2(cuComplex *A, int nr_rows_A, int nr_cols_A);
+__global__
+void transpose(signed char* data, signed char* tra_data);
 
 __global__
 void data_restructure(signed char * data, cuComplex * data_restruc);
 
-void beamform();
-
 __global__
 void sti_reduction(cuComplex * data_in, float * data_out);
 
-
-// Fill the array A(nr_rows_A, nr_cols_A) with random numbers on GPU
-void GPU_fill(cuComplex *A, int nr_rows_A, int nr_cols_A) {
-	cuComplex *G;
-	G = new cuComplex[nr_rows_A*nr_cols_A];
-	for(int i = 0; i < nr_rows_A*nr_cols_A; ++i){
-		G[i].x = (i + 1)%(nr_rows_A*nr_cols_A/(BN_BIN));
-		G[i].y = (i + 1)%(nr_rows_A*nr_cols_A/(BN_BIN));
-
-	}
-
-	cudaMemcpy(A,G,nr_rows_A * nr_cols_A * sizeof(cuComplex),cudaMemcpyHostToDevice);
-	delete[] G;
-}
-
-void GPU_fill2(cuComplex *A, int nr_rows_A, int nr_cols_A) {
-	cuComplex *G;
-	G = new cuComplex[nr_rows_A*nr_cols_A];
-	for(int i = 0; i < nr_rows_A*nr_cols_A; ++i){
-		G[i].x = i%(nr_rows_A*nr_cols_A/(BN_BIN));
-		G[i].y = i%(nr_rows_A*nr_cols_A/(BN_BIN));
-	}
-
-	cudaMemcpy(A,G,nr_rows_A * nr_cols_A * sizeof(cuComplex),cudaMemcpyHostToDevice);
-	delete[] G;
-}
-
-void print_matrix(const cuComplex *A, int nr_rows_A, int nr_cols_A, int nr_sheets_A) {
-	for(int i = 0; i < nr_rows_A; ++i){
-		for(int j = 0; j < nr_cols_A; ++j){
-			for(int k = 0; k < nr_sheets_A; ++k){
-				//				cout << A[j * nr_rows_A + i].x << "+" << A[j * nr_rows_A + i].y << "i" <<" ";
-				printf("%i,%i,%i: %e + %e i\n",i,j,k,A[k*nr_rows_A*nr_cols_A + j * nr_rows_A + i].x, A[k*nr_rows_A*nr_cols_A + j * nr_rows_A + i].y);
-			}
-		}
-		//			cout << endl;
-	}
-	//		cout << endl;
-	//	for(int i = 0; i < nr_rows_A*nr_cols_A; ++i){
-	//		printf("%i,: %e + %e i\n",i,A[i].x, A[i].y);
-	//	}
-}
-
-
-void print_matrix2(const float *A, int nr_rows_A, int nr_cols_A) {
-	//	for(int j = 0; j < nr_cols_A; ++j){
-	//		for(int i = 0; i < nr_rows_A; ++i){
-	//			//cout << A[j * nr_rows_A + i].x << "+" << A[j * nr_rows_A + i].y << "i" <<" ";
-	//			printf("%i,%i: %e\n",i,j,A[j * nr_rows_A + i]);
-	//		}
-	//		cout << endl;
-	//	}
-	//	cout << endl;
-
-	for(int i = 0; i < nr_rows_A*nr_cols_A; ++i){
-		printf("%i,: %e\n",i,A[i]);
-	}
-}
 
 // Struct defintion for beamformer metadata
 typedef struct bf_metadata_struct {
@@ -99,11 +35,16 @@ typedef struct bf_metadata_struct {
 	char weight_filename[65];
 	long long unsigned int xid;
 } bf_metadata;
+
 static bf_metadata my_metadata;
 
+
 static cuComplex * d_weights = NULL;
+
 void update_weights(char * filename){
-	printf("In update_weights()...\n");
+
+	printf("RTBF: In update_weights()...\n");
+
 	char weight_filename[128];
 	strcpy(weight_filename, filename);
 	FILE * weights;
@@ -115,18 +56,23 @@ void update_weights(char * filename){
 	bf_weights = (float *)malloc(2*BN_WEIGHTS*sizeof(float));
 	weights_dc = (float complex *)malloc(BN_WEIGHTS*sizeof(float complex *));
 	weights_dc_n = (float complex *)malloc(BN_WEIGHTS*sizeof(float complex *));
+
+	// open weight file
 	weights = fopen(weight_filename, "r");
 
 	int j;
 	if (weights != NULL) {
+
 		fread(bf_weights, sizeof(float), 2*BN_WEIGHTS, weights);
 
 		fread(my_metadata.offsets, sizeof(float), 14, weights);
 		fread(my_metadata.cal_filename, sizeof(char), 64, weights);
-		my_metadata.cal_filename[64] = '\0';
 		fread(my_metadata.algorithm, sizeof(char), 64, weights);
-		my_metadata.algorithm[64] = '\0';
 		fread(&(my_metadata.xid), sizeof(long long unsigned int), 1, weights);
+
+		my_metadata.cal_filename[64] = '\0';
+		my_metadata.algorithm[64] = '\0';
+
 
 		// Extract all path information from weight_filename for metadata
 		char * short_filename = strrchr(weight_filename, '/');
@@ -136,8 +82,6 @@ void update_weights(char * filename){
 		else {
 			strcpy(my_metadata.weight_filename, weight_filename);
 		}
-
-
 
 		// Convert to complex numbers (do a conjugate at the same time)
 		for(j = 0; j < BN_WEIGHTS; j++){
@@ -159,14 +103,16 @@ void update_weights(char * filename){
 		}
 		fclose(weights);
 	}
-	free(bf_weights);
-
-
 
 	// Copy weights to device
 	cudaMemcpy(d_weights, weights_dc, BN_WEIGHTS*sizeof(cuComplex), cudaMemcpyHostToDevice); //r_weights instead of weights_dc //*BN_TIME
 
+	// free memory
 	free(weights_dc);
+	free(weights_dc_n);
+	free(bf_weights);
+
+	return; 
 }
 
 void bf_get_offsets(float * offsets){
@@ -202,19 +148,24 @@ long long unsigned int bf_get_xid(){
 	return my_metadata.xid;
 }
 
-static cuComplex **d_arr_A = NULL; static cuComplex **d_arr_B = NULL; static cuComplex **d_arr_C = NULL;
 static cuComplex * d_beamformed = NULL;
 static cuComplex * d_data = NULL;
 static signed char * d_data1 = NULL; // Device memory for input data
+static signed char * d_data2 = NULL;
 static float * d_outputs;
 
 static cublasHandle_t handle;
+static cuComplex **d_arr_A = NULL;
+static cuComplex **d_arr_B = NULL;
+static cuComplex **d_arr_C = NULL;
 void init_beamformer(){
-	// Allocate memory for the weights, data, beamformer output, and sti output.
 
+	// Allocate memory for the weights, data, beamformer output, and sti output.
 	cudaMalloc((void **)&d_weights, BN_WEIGHTS*sizeof(cuComplex)); //*BN_TIME
 
 	cudaMalloc((void **)&d_data1, 2*BN_SAMP*sizeof(signed char));
+
+	//cudaMalloc((void **)&d_data2, 2*BN_SAMP*sizeof(signed char));
 
 	cudaMalloc((void **)&d_data, BN_SAMP*sizeof(cuComplex));
 
@@ -225,13 +176,10 @@ void init_beamformer(){
 
 	cudaMalloc((void **)&d_outputs, BN_POL*(BN_OUTPUTS*sizeof(float)/2));
 
-        /**********************************************************
-         * Create a handle for CUBLAS
-         **********************************************************/
-        cublasCreate(&handle);
-
-	// This is all memory allocated to arrays that are used by gemmBatched.
-	// Allocate 3 arrays on CPU
+    /**********************************************************
+    * Create a handle for CUBLAS
+    **********************************************************/
+    cublasCreate(&handle);
 	cudaError_t cudaStat;
 
 	int nr_rows_A, nr_cols_A, nr_rows_B, nr_cols_B, nr_rows_C, nr_cols_C;
@@ -243,8 +191,11 @@ void init_beamformer(){
 	nr_rows_C = BN_BEAM;
 	nr_cols_C = BN_TIME;
 
-	// Allocate memory to host arrays.
-	const cuComplex **h_arr_A = 0; const cuComplex **h_arr_B = 0; cuComplex **h_arr_C = 0;
+	// Allocate memory to host arrays - This is all memory allocated to arrays that are used by gemmBatched. Allocate 3 arrays on CPU
+	const cuComplex **h_arr_A = 0;
+	const cuComplex **h_arr_B = 0;
+	cuComplex **h_arr_C = 0;
+
 	h_arr_A = (const cuComplex **)malloc(nr_rows_A * nr_cols_A *BN_BIN*sizeof(const cuComplex*));
 	h_arr_B = (const cuComplex **)malloc(nr_rows_B * nr_cols_B *BN_BIN*sizeof(const cuComplex*));
 	h_arr_C = (cuComplex **)malloc(nr_rows_C * nr_cols_C *BN_BIN*sizeof(cuComplex*));
@@ -255,9 +206,6 @@ void init_beamformer(){
 		h_arr_B[i] = d_data + i*nr_rows_B*nr_cols_B;
 		h_arr_C[i] = d_beamformed + i*nr_rows_C*nr_cols_C;
 	}
-
-	//	delete[] d_A;
-	//	delete[] d_B;
 
 	// Allocate memory to arrays on device.
 	cudaStat = cudaMalloc((void **)&d_arr_A,nr_rows_A * nr_cols_A * BN_BIN * sizeof(cuComplex*));
@@ -275,19 +223,12 @@ void init_beamformer(){
 	cudaStat = cudaMemcpy(d_arr_C,h_arr_C,nr_rows_C * nr_cols_C * BN_BIN * sizeof(cuComplex*),cudaMemcpyHostToDevice);
 	assert(!cudaStat);
 
+	free(h_arr_A);
+	free(h_arr_B);
+	free(h_arr_C);
+
+	return;
         
-}
-
-__global__
-void data_restructure(signed char * data, cuComplex * data_restruc){
-
-	int e = threadIdx.x;
-	int t = blockIdx.x;
-	int f = blockIdx.y;
-
-	//Restructure data so that the frequency bin is the slowest moving index
-	data_restruc[f*BN_TIME*BN_ELE_BLOC + t*BN_ELE_BLOC + e].x = data[2*(t*BN_BIN*BN_ELE_BLOC + f*BN_ELE_BLOC + e)]*1.0f;
-	data_restruc[f*BN_TIME*BN_ELE_BLOC + t*BN_ELE_BLOC + e].y = data[2*(t*BN_BIN*BN_ELE_BLOC + f*BN_ELE_BLOC + e) + 1]*1.0f;
 }
 
 signed char * data_in(char * input_filename){
@@ -347,7 +288,7 @@ void beamform() {
 	nr_rows_C = BN_BEAM;
 
 	// Leading dimensions are always the rows of each matrix since the data is stored in a column-wise order.
-	int lda=nr_rows_A,ldb=nr_rows_B,ldc=nr_rows_C;
+	int lda=nr_rows_A, ldb=nr_rows_B, ldc=nr_rows_C;
 	cuComplex alf;
 	cuComplex bet;
 
@@ -380,6 +321,11 @@ void beamform() {
 			ldc,							// Leading dimension of each batch or matrix in array C.
 			batchCount);					// Number of batches in each array.
 
+	if (stat == CUBLAS_STATUS_INVALID_VALUE) {
+		printf("RTBF: Invalid CUBLAS values\n");
+	} else if (stat == CUBLAS_STATUS_EXECUTION_FAILED) {
+		printf("RTBF: Execution failed.\n");
+	}
 
 	if(stat != CUBLAS_STATUS_SUCCESS){
 		cerr << "cublasCgemmBatched failed" << endl;
@@ -387,15 +333,79 @@ void beamform() {
 	}
 	assert(!cudaGetLastError());
 
-	//Free GPU memory
-	//	cudaFree(d_A);
-	//	cudaFree(d_B);
-	//	cudaFree(d_C);
-
-	// Destroy the handle
-	//cublasDestroy(handle);
-
 }
+
+__global__ 
+void transpose(signed char* data, signed char* tra_data) {
+	int i = threadIdx.x; 
+	int c = threadIdx.y;
+
+	int m = blockIdx.x;
+	int f = blockIdx.y;
+	int t = blockIdx.z;
+
+	//int Nm = gridDim.x; // number of mcnts (packets)
+	int Nf = gridDim.y; // number of f-engines (ROACHES)
+	int Nt = gridDim.z; // time samples per mcnt
+
+	int Ni = blockDim.x; // inputs per f-engine (aka antenna elements per ROACH)
+	int Nc = blockDim.y; // bins per mcnt
+
+	int in_idx  = i + Ni*c + Nc*Ni*t + Nt*Nc*Ni*f + Nf*Nt*Nc*Ni*m;	
+	int out_idx = i + Ni*f + Nf*Ni*c + Nc*Nf*Ni*t + Nt*Nc*Nf*Ni*m;
+
+	tra_data[2*out_idx] = data[2*in_idx];
+	tra_data[2*out_idx + 1] = data[2*in_idx+1];
+
+	return;
+}
+
+__global__
+void data_restructure(signed char * data, cuComplex * data_restruc){
+
+	/*
+		Repurpose the transpose thread in the hashpipe codes by performing the transpose in the GPU.
+		The motivation was, why transpose then transpose again? Why not just perform one transpose
+		in the GPU which would be faster anyway.
+	*/
+
+	int i = threadIdx.x; 
+	int c = threadIdx.y;
+
+	int m = blockIdx.x;
+	int f = blockIdx.y;
+	int t = blockIdx.z;
+
+	int Nm = gridDim.x; // number of mcnts (packets)
+	int Nf = gridDim.y; // number of f-engines (ROACHES)
+	int Nt = gridDim.z; // time samples per mcnt
+
+	int Ni = blockDim.x; // inputs per f-engine (aka antenna elements per ROACH)
+	int Nc = blockDim.y; // bins per mcnt
+
+	int in_idx  = i + Ni*c + Nc*Ni*t + Nt*Nc*Ni*f + Nf*Nt*Nc*Ni*m;
+	int out_idx = i + Ni*f + Nf*Ni*t + Nt*Nf*Ni*m + Nm*Nt*Nf*Ni*c;
+
+	data_restruc[out_idx].x = data[2*in_idx]*1.0f;
+	data_restruc[out_idx].y = data[2*in_idx + 1]*1.0f;
+
+	return;
+
+	/*
+	// Original Code
+	int e = threadIdx.x;
+	int t = blockIdx.x;
+	int f = blockIdx.y;
+
+	//Restructure data so that the frequency bin is the slowest moving index
+	data_restruc[f*BN_TIME*BN_ELE_BLOC + t*BN_ELE_BLOC + e].x = data[2*(t*BN_BIN*BN_ELE_BLOC + f*BN_ELE_BLOC + e)]*1.0f;
+	data_restruc[f*BN_TIME*BN_ELE_BLOC + t*BN_ELE_BLOC + e].y = data[2*(t*BN_BIN*BN_ELE_BLOC + f*BN_ELE_BLOC + e) + 1]*1.0f;
+	
+
+	return;
+	*/
+}
+
 
 __global__
 void sti_reduction(cuComplex * data_in, float * data_out) {
@@ -406,7 +416,7 @@ void sti_reduction(cuComplex * data_in, float * data_out) {
 	int s = blockIdx.z;
 
 	int h = sample_idx(s*BN_TIME_STI + t,b,f);						// Preprocessor macro used for the output of the beamformer. More detail can be seen in the header file. (First set of beams)
-	int h1 = sample_idx(s*BN_TIME_STI + t,b+BN_BEAM1,f);				// Preprocessor macro used for the output of the beamformer. More detail can be seen in the header file. (Last set of beams)
+	int h1 = sample_idx(s*BN_TIME_STI + t,b+BN_BEAM1,f);			// Preprocessor macro used for the output of the beamformer. More detail can be seen in the header file. (Last set of beams)
 
 	// Temporary variables used for updating.
 	float beam_power1;
@@ -467,9 +477,13 @@ void sti_reduction(cuComplex * data_in, float * data_out) {
 		data_out[output_idx(2,b,s,f)] = reduced_array1[0].x*scale; 	// XY* real.
 		data_out[output_idx(3,b,s,f)] = reduced_array1[0].y*scale;	// XY* imaginary.
 	}
+
+	return;
 }
 
 void run_beamformer(signed char * data_in, float * data_out) {
+
+	cudaError_t err_code;
 	// Specify grid and block dimensions
 	dim3 dimBlock(BN_STI_BLOC, 1, 1);
 	dim3 dimGrid(BN_BIN, BN_BEAM1, BN_STI);
@@ -478,19 +492,43 @@ void run_beamformer(signed char * data_in, float * data_out) {
 	dim3 dimBlock_d(BN_ELE_BLOC, 1, 1);
 	dim3 dimGrid_d(BN_TIME, BN_BIN, 1);
 
-	signed char * d_restruct_in = d_data1;
+	int Nm = 200;
+	int Nf = 8;
+	int Nt = 20;
+	int Nc = 25;
+	int Ni = 8;
+	dim3 gridDim_transpose(Nm, Nf, Nt);
+	dim3 blockDim_transpose(Ni, Nc, 1);
+
+	signed char* d_tra_data_in = d_data1;
+	//signed char* d_tra_data_out = d_data2;
+	//signed char * d_restruct_in = d_data1;
 	cuComplex * d_restruct_out = d_data;
 
-	cudaMemcpy(d_restruct_in, data_in, 2*BN_SAMP*sizeof(signed char), cudaMemcpyHostToDevice);
+	//cudaMemcpy(d_restruct_in, data_in, 2*BN_SAMP*sizeof(signed char), cudaMemcpyHostToDevice);
+	cudaMemcpy(d_tra_data_in, data_in, 2*BN_SAMP*sizeof(signed char), cudaMemcpyHostToDevice);
+	err_code = cudaGetLastError();
+	if (err_code != cudaSuccess) {
+		printf("RTBF: cudaMemcpy Failed: %s\n", cudaGetErrorString(err_code));
+	}
+
+	// Transpose the data
+	// transpose<<<gridDim_transpose, blockDim_transpose>>>(d_tra_data_in, d_tra_data_out);
+	// if (err_code != cudaSuccess) {
+	// 	printf("RTBF: CUDA Error (transpose): %s\n", cudaGetErrorString(err_code));
+	// }
 
 	// Restructure data for cublasCgemmBatched function.
-	data_restructure<<<dimGrid_d, dimBlock_d>>>(d_restruct_in, d_restruct_out);
-
-//	printf("Starting beamformer\n");
+	data_restructure<<<dimGrid_d, dimBlock_d>>>(d_tra_data_in, d_restruct_out);
+	//data_restructure<<<gridDim_transpose, blockDim_transpose>>>(d_restruct_in, d_restruct_out);
+	//data_restructure<<<dimGrid_d, dimBlock_d>>>(d_restruct_in, d_restruct_out);
+	if (err_code != cudaSuccess) {
+		printf("RTBF: CUDA Error (data_restructure): %s\n", cudaGetErrorString(err_code));
+	}
 
 	// Call beamformer function containing cublasCgemmBatched()
 	beamform();
-	cudaError_t err_code = cudaGetLastError();
+	err_code = cudaGetLastError();
 	if (err_code != cudaSuccess) {
 		printf("CUDA Error (beamform): %s\n", cudaGetErrorString(err_code));
 	}
@@ -498,12 +536,8 @@ void run_beamformer(signed char * data_in, float * data_out) {
 	cuComplex * d_sti_in = d_beamformed;
 	float * d_sti_out = d_outputs;
 
-//	printf("Starting sti_reduction\n");
-
 	// Call STI reduction kernel.
 	sti_reduction<<<dimGrid, dimBlock>>>(d_sti_in, d_sti_out);
-
-//	printf("Finishing sti_reduction\n");
 
 	err_code = cudaGetLastError();
 	if (err_code != cudaSuccess) {
@@ -513,8 +547,7 @@ void run_beamformer(signed char * data_in, float * data_out) {
 	// Copy output data from device to host.
 	cudaMemcpy(data_out, d_sti_out, BN_POL*(BN_OUTPUTS*sizeof(float)/2),cudaMemcpyDeviceToHost);
 
-	// cudaFree(d_data);
-	// cudaFree(d_outputs);
+	return;
 }
 
 
@@ -530,6 +563,10 @@ void rtbfCleanup() {
 
 	if (d_data1 != NULL) {
 		cudaFree(d_data1);
+	}
+
+	if (d_data2 != NULL) {
+		cudaFree(d_data2);
 	}
 
 	if (d_outputs != NULL) {
@@ -553,4 +590,5 @@ void rtbfCleanup() {
 	}
 	// Free up and release cublas handle
 	cublasDestroy(handle);
+
 }

--- a/lib/pfb/src/pfb.cu
+++ b/lib/pfb/src/pfb.cu
@@ -117,7 +117,6 @@ int runPFB(signed char* inputData_h, float* outputData_h, params pfbParams) {
 
 	int outDataSize = countFFT * g_iNumSubBands * g_iNFFT;
 	//CUDASafeCallWithCleanUp(cudaMemcpy(outputData_h, fftOutPtr, outDataSize*sizeof(cufftComplex), cudaMemcpyDeviceToHost));
-	//printf("making sure new build...\n");
 	CUDASafeCallWithCleanUp(cudaMemcpy(outputData_h, g_pf2FFTOut_d, outDataSize*sizeof(cufftComplex), cudaMemcpyDeviceToHost));
 
 	return iRet;

--- a/lib/pfb/src/pfb.cu
+++ b/lib/pfb/src/pfb.cu
@@ -124,6 +124,13 @@ int runPFB(signed char* inputData_h, float* outputData_h, params pfbParams) {
 
 }
 
+void flushBuffer(params pfbParams) {
+
+	int start = pfbParams.fine_channels*pfbParams.elements*pfbParams.nfft*pfbParams.taps;
+	CUDASafeCallWithCleanUp(cudaMemset((void *)   g_pc2Data_d, 0, start*2*sizeof(char)));
+	return;
+}
+
 // return true or false upon successful setup.
 int initPFB(int iCudaDevice, params pfbParams){
 

--- a/lib/pfb/src/pfb.h
+++ b/lib/pfb/src/pfb.h
@@ -56,5 +56,6 @@ int runPFB(signed char* inputData_h, float* outputData_h, params pfbParams);
 int doFFT();
 int resetDevice(void);
 void cleanUp(void);
+void flushBuffer(params pfbParams);
 
 #endif

--- a/lib/pfb/src/pfb.h
+++ b/lib/pfb/src/pfb.h
@@ -16,7 +16,7 @@
 
 #define FALSE 					0
 #define TRUE  					1
-#define DEBUG					1
+//#define DEBUG					1
 
 #define DEF_CUDA_DEVICE			0
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -41,9 +41,15 @@ flag_x_threads = flag_net_thread.c \
                  flag_correlator_thread.c \
                  flag_corsave_thread.c
 
+# CPU Transpose
+#flag_b_threads = flag_net_thread.c \
+#                 flag_transpose_thread.c \
+#                 flag_beamform_thread.c \
+#                 flag_beamsave_thread.c
+
+# GPU Transpose
 flag_b_threads = flag_net_thread.c \
-                 flag_transpose_thread.c \
-                 flag_beamform_thread.c \
+                 flag_transpose_beamform_thread.c \
                  flag_beamsave_thread.c
 
 flag_f_threads = flag_net_thread.c \

--- a/src/fifo.c
+++ b/src/fifo.c
@@ -138,12 +138,12 @@ cmd_t check_cmd(int fifo_fd)
         }
         else if (strncasecmp(cmd,"STOP",MAX_CMD_LEN)==0)
 		{
-                        printf("FIFO: A STOP was issued to the hashpipe codes!!!!!!!!!!!!!!!!!!\n");
+            printf("FIFO: A STOP was issued to the hashpipe codes!!!!!!!!!!!!!!!!!!\n");
 			return STOP;
 		}
 		else if (strncasecmp(cmd,"QUIT",MAX_CMD_LEN)==0)
 		{
-                        printf("FIFO: A QUIT was issued to the hashpipe codes!!!!!!!!!!!!!!!!!!\n");
+            printf("FIFO: A QUIT was issued to the hashpipe codes!!!!!!!!!!!!!!!!!!\n");
 			return QUIT;
 		}
         else

--- a/src/flag_correlator_thread.c
+++ b/src/flag_correlator_thread.c
@@ -117,7 +117,7 @@ static void * run(hashpipe_thread_args_t * args) {
             // Print out the header information for this block 
             flag_gpu_input_header_t tmp_header;
             memcpy(&tmp_header, &db_in->block[curblock_in].header, sizeof(flag_gpu_input_header_t));
-	    //printf("COR: Received block %d, starting mcnt = %lld\n", curblock_in, (long long int)tmp_header.mcnt);
+            //printf("COR: Received block %d, starting mcnt = %lld\n", curblock_in, (long long int)tmp_header.mcnt);
             good_data &= tmp_header.good_data;
             hashpipe_status_lock_safe(&st);
             hputi4(st.buf, "CORMCNT", tmp_header.mcnt);
@@ -151,8 +151,8 @@ static void * run(hashpipe_thread_args_t * args) {
                 // Check to see if block's starting mcnt matches INTSYNC
                 if (db_in->block[curblock_in].header.mcnt < start_mcnt) {
 
-		    // If we get here, then there is a bug since the net thread shouldn't
-		    // mark blocks as filled that are before the starting mcnt
+                    // If we get here, then there is a bug since the net thread shouldn't
+                    // mark blocks as filled that are before the starting mcnt
                     // fprintf(stderr, "COR: Unable to start yet... waiting for mcnt = %lld\n", (long long int)start_mcnt);
 
                     // starting mcnt not yet reached
@@ -163,7 +163,9 @@ static void * run(hashpipe_thread_args_t * args) {
                 }
                 else if (db_in->block[curblock_in].header.mcnt == start_mcnt) {
                     // set correlator integrator to "on"
-                    // fprintf(stderr, "COR: Starting correlator!\n");
+                    #if VERBOSE
+                    fprintf(stderr, "COR: Starting correlator!\n");
+                    #endif
                     strcpy(integ_status, "on");
                     float requested_integration_time = 0.0;
                     float actual_integration_time = 0.0;
@@ -185,7 +187,7 @@ static void * run(hashpipe_thread_args_t * args) {
                 }
                 else {
                     // fprintf(stdout, "COR: We missed the start of the integration\n");
-		    fprintf(stdout, "COR: Missed start. Expected start_mcnt = %lld, got %lld\n", (long long int)start_mcnt, (long long int)db_in->block[curblock_in].header.mcnt);
+                    fprintf(stdout, "COR: Missed start. Expected start_mcnt = %lld, got %lld\n", (long long int)start_mcnt, (long long int)db_in->block[curblock_in].header.mcnt);
                     // we apparently missed the start of the integation... ouch...
                 }
             }
@@ -201,7 +203,15 @@ static void * run(hashpipe_thread_args_t * args) {
             context.output_offset = curblock_out * sizeof(flag_gpu_correlator_output_block_t) / sizeof(Complex);
         
             int doDump = 0;
-            if ((db_in->block[curblock_in].header.mcnt + int_count*Nm - 1) >= last_mcnt) {
+            if ((db_in->block[curblock_in].header.mcnt + Nm - 1) >= last_mcnt) {
+
+                #if VERBOSE
+                printf("COR: Setting dump\n\t last_mcnt=%lld\n\t int_count=%d\n\t rx_mcnt=%lld\n\t Nm=%d\n",
+                                    (long long int)last_mcnt,
+                                    int_count,
+                                    (long long int)(db_in->block[curblock_in].header.mcnt),
+                                    Nm);
+                #endif
                 doDump = 1;
 
                 // Wait for new output block to be free

--- a/src/flag_databuf.c
+++ b/src/flag_databuf.c
@@ -25,8 +25,6 @@ int flag_input_databuf_set_filled(flag_input_databuf_t * d, int block_id) {
     return hashpipe_databuf_set_filled((hashpipe_databuf_t *)d, block_id);
 }
 
-
-
 hashpipe_databuf_t * flag_gpu_input_databuf_create(int instance_id, int databuf_id) {
     size_t header_size = sizeof(hashpipe_databuf_t) + sizeof(hashpipe_databuf_cache_alignment);
     size_t block_size  = sizeof(flag_gpu_input_block_t);
@@ -77,36 +75,7 @@ int flag_frb_gpu_input_databuf_set_filled(flag_frb_gpu_input_databuf_t * d, int 
     return hashpipe_databuf_set_filled((hashpipe_databuf_t *)d, block_id);
 }
 
-
-
-
-hashpipe_databuf_t * flag_pfb_gpu_input_databuf_create(int instance_id, int databuf_id) {
-    size_t header_size = sizeof(hashpipe_databuf_t) + sizeof(hashpipe_databuf_cache_alignment);
-    size_t block_size  = sizeof(flag_pfb_gpu_input_block_t);
-    int    n_block     = N_GPU_INPUT_BLOCKS;
-    return hashpipe_databuf_create(
-        instance_id, databuf_id, header_size, block_size, n_block);
-}
-
-int flag_pfb_gpu_input_databuf_wait_free(flag_pfb_gpu_input_databuf_t * d, int block_id) {
-    return hashpipe_databuf_wait_free((hashpipe_databuf_t *)d, block_id);
-}
-
-int flag_pfb_gpu_input_databuf_wait_filled(flag_pfb_gpu_input_databuf_t * d, int block_id) {
-    return hashpipe_databuf_wait_filled((hashpipe_databuf_t *)d, block_id);
-}
-
-int flag_pfb_gpu_input_databuf_set_free(flag_pfb_gpu_input_databuf_t * d, int block_id) {
-    return hashpipe_databuf_set_free((hashpipe_databuf_t *)d, block_id);
-}
-
-int flag_pfb_gpu_input_databuf_set_filled(flag_pfb_gpu_input_databuf_t * d, int block_id) {
-    return hashpipe_databuf_set_filled((hashpipe_databuf_t *)d, block_id);
-}
-
-
-
-
+// Overloaded methods for the coarse correlator
 hashpipe_databuf_t * flag_gpu_correlator_output_databuf_create(int instance_id, int databuf_id) {
     size_t header_size = sizeof(hashpipe_databuf_t) + sizeof(hashpipe_databuf_cache_alignment);
     size_t block_size  = sizeof(flag_gpu_correlator_output_block_t);
@@ -131,6 +100,7 @@ int flag_gpu_correlator_output_databuf_set_filled(flag_gpu_correlator_output_dat
     return hashpipe_databuf_set_filled((hashpipe_databuf_t *)d, block_id);
 }
 
+//Overloaded methods for the frb correlator
 hashpipe_databuf_t * flag_frb_gpu_correlator_output_databuf_create(int instance_id, int databuf_id) {
     size_t header_size = sizeof(hashpipe_databuf_t) + sizeof(hashpipe_databuf_cache_alignment);
     size_t block_size  = sizeof(flag_frb_gpu_correlator_output_block_t);
@@ -155,7 +125,7 @@ int flag_frb_gpu_correlator_output_databuf_set_filled(flag_frb_gpu_correlator_ou
     return hashpipe_databuf_set_filled((hashpipe_databuf_t *)d, block_id);
 }
 
-
+//Overloaded methods for the fine correlator
 hashpipe_databuf_t * flag_pfb_gpu_correlator_output_databuf_create(int instance_id, int databuf_id) {
     size_t header_size = sizeof(hashpipe_databuf_t) + sizeof(hashpipe_databuf_cache_alignment);
     size_t block_size  = sizeof(flag_pfb_gpu_correlator_output_block_t);
@@ -180,26 +150,7 @@ int flag_pfb_gpu_correlator_output_databuf_set_filled(flag_pfb_gpu_correlator_ou
     return hashpipe_databuf_set_filled((hashpipe_databuf_t *)d, block_id);
 }
 
-int flag_pfb_gpu_correlator_output_databuf_total_status(flag_pfb_gpu_correlator_output_databuf_t * d) {
-    return hashpipe_databuf_total_status((hashpipe_databuf_t *)d);
-}
-
-int flag_gpu_pfb_output_databuf_total_status(flag_gpu_pfb_output_databuf_t * d) {
-    return hashpipe_databuf_total_status((hashpipe_databuf_t *)d);
-}
-
-int flag_pfb_gpu_input_databuf_total_status(flag_pfb_gpu_input_databuf_t * d) {
-    return hashpipe_databuf_total_status((hashpipe_databuf_t *) d);
-}
-
-int flag_input_databuf_total_status(flag_input_databuf_t * d) {
-    return hashpipe_databuf_total_status((hashpipe_databuf_t *) d);
-}
-
-int flag_gpu_correlator_output_databuf_total_status(flag_gpu_correlator_output_databuf_t * d) {
-    return hashpipe_databuf_total_status((hashpipe_databuf_t *) d);
-}
-
+// Overloaded methods for beamformer
 hashpipe_databuf_t * flag_gpu_beamformer_output_databuf_create(int instance_id, int databuf_id) {
     size_t header_size = sizeof(hashpipe_databuf_t) + sizeof(hashpipe_databuf_cache_alignment);
     size_t block_size  = sizeof(flag_gpu_beamformer_output_block_t);
@@ -224,6 +175,40 @@ int flag_gpu_beamformer_output_databuf_set_filled(flag_gpu_beamformer_output_dat
     return hashpipe_databuf_set_filled((hashpipe_databuf_t *)d, block_id);
 }
 
+//overloaded methods for pfb input buffers
+hashpipe_databuf_t * flag_pfb_gpu_input_databuf_create(int instance_id, int databuf_id) {
+    size_t header_size = sizeof(hashpipe_databuf_t) + sizeof(hashpipe_databuf_cache_alignment);
+    size_t block_size  = sizeof(flag_pfb_gpu_input_block_t);
+    int    n_block     = N_GPU_INPUT_BLOCKS;
+    return hashpipe_databuf_create(
+        instance_id, databuf_id, header_size, block_size, n_block);
+}
+
+int flag_pfb_gpu_input_databuf_wait_free(flag_pfb_gpu_input_databuf_t * d, int block_id) {
+    return hashpipe_databuf_wait_free((hashpipe_databuf_t *)d, block_id);
+}
+
+int flag_pfb_gpu_input_databuf_wait_filled(flag_pfb_gpu_input_databuf_t * d, int block_id) {
+    return hashpipe_databuf_wait_filled((hashpipe_databuf_t *)d, block_id);
+}
+
+int flag_pfb_gpu_input_databuf_set_free(flag_pfb_gpu_input_databuf_t * d, int block_id) {
+    return hashpipe_databuf_set_free((hashpipe_databuf_t *)d, block_id);
+}
+
+int flag_pfb_gpu_input_databuf_set_filled(flag_pfb_gpu_input_databuf_t * d, int block_id) {
+    return hashpipe_databuf_set_filled((hashpipe_databuf_t *)d, block_id);
+}
+
+void flag_pfb_gpu_input_databuf_clear(flag_pfb_gpu_input_databuf_t * d) {
+    return hashpipe_databuf_clear((hashpipe_databuf_t *)d);
+}
+
+void flag_databuf_clear(hashpipe_databuf_t * d) {
+    return hashpipe_databuf_clear(d);
+}
+
+// Overloaded methods for pfb output buffers
 hashpipe_databuf_t * flag_gpu_pfb_output_databuf_create(int instance_id, int databuf_id) {
     size_t header_size = sizeof(hashpipe_databuf_t) + sizeof(hashpipe_databuf_cache_alignment);
     size_t block_size  = sizeof(flag_gpu_pfb_output_block_t);
@@ -248,6 +233,11 @@ int flag_gpu_pfb_output_databuf_set_filled(flag_gpu_pfb_output_databuf_t* d, int
     return hashpipe_databuf_set_filled((hashpipe_databuf_t *)d, block_id);
 }
 
+void flag_gpu_pfb_output_databuf_clear(flag_gpu_pfb_output_databuf_t* d) {
+    return hashpipe_databuf_clear((hashpipe_databuf_t *)d);
+}
+
+//overloaded methods for total power
 hashpipe_databuf_t * flag_gpu_power_output_databuf_create(int instance_id, int databuf_id) {
     size_t header_size = sizeof(hashpipe_databuf_t) + sizeof(hashpipe_databuf_cache_alignment);
     size_t block_size  = sizeof(flag_gpu_power_output_block_t);
@@ -270,4 +260,27 @@ int flag_gpu_power_output_databuf_set_free(flag_gpu_power_output_databuf_t * d, 
 
 int flag_gpu_power_output_databuf_set_filled(flag_gpu_power_output_databuf_t * d, int block_id) {
     return hashpipe_databuf_set_filled((hashpipe_databuf_t *)d, block_id);
+}
+
+
+
+// Overloaded methods for databuf total status
+int flag_pfb_gpu_correlator_output_databuf_total_status(flag_pfb_gpu_correlator_output_databuf_t * d) {
+    return hashpipe_databuf_total_status((hashpipe_databuf_t *)d);
+}
+
+int flag_gpu_pfb_output_databuf_total_status(flag_gpu_pfb_output_databuf_t * d) {
+    return hashpipe_databuf_total_status((hashpipe_databuf_t *)d);
+}
+
+int flag_pfb_gpu_input_databuf_total_status(flag_pfb_gpu_input_databuf_t * d) {
+    return hashpipe_databuf_total_status((hashpipe_databuf_t *) d);
+}
+
+int flag_input_databuf_total_status(flag_input_databuf_t * d) {
+    return hashpipe_databuf_total_status((hashpipe_databuf_t *) d);
+}
+
+int flag_gpu_correlator_output_databuf_total_status(flag_gpu_correlator_output_databuf_t * d) {
+    return hashpipe_databuf_total_status((hashpipe_databuf_t *) d);
 }

--- a/src/flag_databuf.c
+++ b/src/flag_databuf.c
@@ -107,7 +107,6 @@ int flag_pfb_gpu_input_databuf_set_filled(flag_pfb_gpu_input_databuf_t * d, int 
 
 
 
-
 hashpipe_databuf_t * flag_gpu_correlator_output_databuf_create(int instance_id, int databuf_id) {
     size_t header_size = sizeof(hashpipe_databuf_t) + sizeof(hashpipe_databuf_cache_alignment);
     size_t block_size  = sizeof(flag_gpu_correlator_output_block_t);
@@ -181,6 +180,25 @@ int flag_pfb_gpu_correlator_output_databuf_set_filled(flag_pfb_gpu_correlator_ou
     return hashpipe_databuf_set_filled((hashpipe_databuf_t *)d, block_id);
 }
 
+int flag_pfb_gpu_correlator_output_databuf_total_status(flag_pfb_gpu_correlator_output_databuf_t * d) {
+    return hashpipe_databuf_total_status((hashpipe_databuf_t *)d);
+}
+
+int flag_gpu_pfb_output_databuf_total_status(flag_gpu_pfb_output_databuf_t * d) {
+    return hashpipe_databuf_total_status((hashpipe_databuf_t *)d);
+}
+
+int flag_pfb_gpu_input_databuf_total_status(flag_pfb_gpu_input_databuf_t * d) {
+    return hashpipe_databuf_total_status((hashpipe_databuf_t *) d);
+}
+
+int flag_input_databuf_total_status(flag_input_databuf_t * d) {
+    return hashpipe_databuf_total_status((hashpipe_databuf_t *) d);
+}
+
+int flag_gpu_correlator_output_databuf_total_status(flag_gpu_correlator_output_databuf_t * d) {
+    return hashpipe_databuf_total_status((hashpipe_databuf_t *) d);
+}
 
 hashpipe_databuf_t * flag_gpu_beamformer_output_databuf_create(int instance_id, int databuf_id) {
     size_t header_size = sizeof(hashpipe_databuf_t) + sizeof(hashpipe_databuf_cache_alignment);

--- a/src/flag_databuf.h
+++ b/src/flag_databuf.h
@@ -8,7 +8,7 @@
 #include "pfb.h"
 #include "config.h"
 
-#define VERBOSE 0 
+#define VERBOSE 0
 #define SAVE 0
 
 // Total number of antennas (nominally 40)
@@ -162,7 +162,7 @@ typedef uint8_t hashpipe_databuf_cache_alignment[
  * It is the input buffer of the flag_transpose_thread.
  */
 
-#define N_INPUT_BLOCKS 100
+#define N_INPUT_BLOCKS 4
 
 // A typedef for a block header
 typedef struct flag_input_header {
@@ -422,6 +422,14 @@ int flag_pfb_gpu_correlator_output_databuf_wait_free   (flag_pfb_gpu_correlator_
 int flag_pfb_gpu_correlator_output_databuf_wait_filled (flag_pfb_gpu_correlator_output_databuf_t * d, int block_id);
 int flag_pfb_gpu_correlator_output_databuf_set_free    (flag_pfb_gpu_correlator_output_databuf_t * d, int block_id);
 int flag_pfb_gpu_correlator_output_databuf_set_filled  (flag_pfb_gpu_correlator_output_databuf_t * d, int block_id);
+
+int flag_pfb_gpu_correlator_output_databuf_total_status (flag_pfb_gpu_correlator_output_databuf_t * d);
+int flag_gpu_pfb_output_databuf_total_status (flag_gpu_pfb_output_databuf_t * d);
+
+int flag_pfb_gpu_input_databuf_total_status(flag_pfb_gpu_input_databuf_t * d);
+int flag_gpu_correlator_output_databuf_total_status(flag_gpu_correlator_output_databuf_t * d);
+
+int flag_input_databuf_total_status(flag_input_databuf_t * d);
 
 hashpipe_databuf_t * flag_gpu_beamformer_output_databuf_create(int instance_id, int databuf_id);
 

--- a/src/flag_databuf.h
+++ b/src/flag_databuf.h
@@ -10,6 +10,7 @@
 
 #define VERBOSE 0
 #define SAVE 0
+#define DEBUG 0
 
 // Total number of antennas (nominally 40)
 #define N_INPUTS 64
@@ -162,7 +163,7 @@ typedef uint8_t hashpipe_databuf_cache_alignment[
  * It is the input buffer of the flag_transpose_thread.
  */
 
-#define N_INPUT_BLOCKS 4
+#define N_INPUT_BLOCKS 4 //50
 
 // A typedef for a block header
 typedef struct flag_input_header {
@@ -398,6 +399,9 @@ int flag_pfb_gpu_input_databuf_wait_free   (flag_pfb_gpu_input_databuf_t * d, in
 int flag_pfb_gpu_input_databuf_wait_filled (flag_pfb_gpu_input_databuf_t * d, int block_id);
 int flag_pfb_gpu_input_databuf_set_free    (flag_pfb_gpu_input_databuf_t * d, int block_id);
 int flag_pfb_gpu_input_databuf_set_filled  (flag_pfb_gpu_input_databuf_t * d, int block_id);
+void flag_pfb_gpu_input_databuf_clear(flag_pfb_gpu_input_databuf_t * d);
+
+void flag_databuf_clear(hashpipe_databuf_t * d);
 
 /********************
  * GPU Output Buffer Functions
@@ -423,14 +427,6 @@ int flag_pfb_gpu_correlator_output_databuf_wait_filled (flag_pfb_gpu_correlator_
 int flag_pfb_gpu_correlator_output_databuf_set_free    (flag_pfb_gpu_correlator_output_databuf_t * d, int block_id);
 int flag_pfb_gpu_correlator_output_databuf_set_filled  (flag_pfb_gpu_correlator_output_databuf_t * d, int block_id);
 
-int flag_pfb_gpu_correlator_output_databuf_total_status (flag_pfb_gpu_correlator_output_databuf_t * d);
-int flag_gpu_pfb_output_databuf_total_status (flag_gpu_pfb_output_databuf_t * d);
-
-int flag_pfb_gpu_input_databuf_total_status(flag_pfb_gpu_input_databuf_t * d);
-int flag_gpu_correlator_output_databuf_total_status(flag_gpu_correlator_output_databuf_t * d);
-
-int flag_input_databuf_total_status(flag_input_databuf_t * d);
-
 hashpipe_databuf_t * flag_gpu_beamformer_output_databuf_create(int instance_id, int databuf_id);
 
 int flag_gpu_beamformer_output_databuf_wait_free   (flag_gpu_beamformer_output_databuf_t * d, int block_id);
@@ -444,6 +440,7 @@ int flag_gpu_pfb_output_databuf_wait_free   (flag_gpu_pfb_output_databuf_t * d, 
 int flag_gpu_pfb_output_databuf_wait_filled (flag_gpu_pfb_output_databuf_t * d, int block_id);
 int flag_gpu_pfb_output_databuf_set_free    (flag_gpu_pfb_output_databuf_t * d, int block_id);
 int flag_gpu_pfb_output_databuf_set_filled  (flag_gpu_pfb_output_databuf_t * d, int block_id);
+void flag_gpu_pfb_output_databuf_clear(flag_gpu_pfb_output_databuf_t* d);
 
 hashpipe_databuf_t * flag_gpu_power_output_databuf_create(int instance_id, int databuf_id);
 
@@ -451,6 +448,15 @@ int flag_gpu_power_output_databuf_wait_free   (flag_gpu_power_output_databuf_t *
 int flag_gpu_power_output_databuf_wait_filled (flag_gpu_power_output_databuf_t * d, int block_id);
 int flag_gpu_power_output_databuf_set_free    (flag_gpu_power_output_databuf_t * d, int block_id);
 int flag_gpu_power_output_databuf_set_filled  (flag_gpu_power_output_databuf_t * d, int block_id);
+
+// overloaded helper methods
+int flag_pfb_gpu_correlator_output_databuf_total_status (flag_pfb_gpu_correlator_output_databuf_t * d);
+int flag_gpu_pfb_output_databuf_total_status (flag_gpu_pfb_output_databuf_t * d);
+
+int flag_pfb_gpu_input_databuf_total_status(flag_pfb_gpu_input_databuf_t * d);
+int flag_gpu_correlator_output_databuf_total_status(flag_gpu_correlator_output_databuf_t * d);
+
+int flag_input_databuf_total_status(flag_input_databuf_t * d);
 
 #endif
 

--- a/src/flag_pfb_correlator_thread.c
+++ b/src/flag_pfb_correlator_thread.c
@@ -295,7 +295,10 @@ static void * run(hashpipe_thread_args_t * args) {
             }
         }
         else if (cur_state == CLEANUP) {
-            //printf("COR: In Cleanup\n");
+            
+            if (VERBOSE) {
+                printf("COR: In Cleanup\n");
+            }
 
             hashpipe_status_lock_safe(&st);
             hgets(st.buf, "NETSTAT", 16, netstat);
@@ -303,6 +306,8 @@ static void * run(hashpipe_thread_args_t * args) {
 
             if (strcmp(netstat, "IDLE") == 0) {
                 next_state = ACQUIRE;
+                flag_databuf_clear((hashpipe_databuf_t *) db_out);
+                printf("COR: Finished CLEANUP, clearing output databuf and returning to ACQUIRE\n");   
 
             } else {
                 next_state = CLEANUP;

--- a/src/flag_pfb_correlator_thread.c
+++ b/src/flag_pfb_correlator_thread.c
@@ -109,11 +109,12 @@ static void * run(hashpipe_thread_args_t * args) {
     state next_state = ACQUIRE;
     char netstat[17];
     int64_t good_data = 1;
+
     while (run_threads()) {
        
         if (cur_state == ACQUIRE) {
             next_state = ACQUIRE;
-	    // Wait for input buffer block to be filled
+            // Wait for input buffer block to be filled
             while ((rv=flag_gpu_pfb_output_databuf_wait_filled(db_in, curblock_in)) != HASHPIPE_OK && run_threads()) {
                 if (rv==HASHPIPE_TIMEOUT) {
                     int cleanc;
@@ -136,186 +137,201 @@ static void * run(hashpipe_thread_args_t * args) {
             if (!run_threads()) break;
 
             if (next_state != CLEANUP) {
-            // Print out the header information for this block 
-            flag_gpu_input_header_t tmp_header;
-            memcpy(&tmp_header, &db_in->block[curblock_in].header, sizeof(flag_gpu_input_header_t));
-            #if VERBOSE==1
-    	        printf("COR: Received block %d, starting mcnt = %lld\n", curblock_in, (long long int)tmp_header.mcnt);
-	    #endif
-            good_data &= tmp_header.good_data;
-            hashpipe_status_lock_safe(&st);
-            hputi4(st.buf, "CORMCNT", tmp_header.mcnt);
-            hashpipe_status_unlock_safe(&st);
-
-            // Retrieve correlator integrator status
-            hashpipe_status_lock_safe(&st);
-            hgets(st.buf, "INTSTAT", 16, integ_status);
-            hashpipe_status_unlock_safe(&st);
-        
-            // If the correlator integrator status is "off,"
-            // Free the input block and continue
-            if (strcmp(integ_status, "off") == 0) {
+                // Print out the header information for this block 
+                flag_gpu_input_header_t tmp_header;
+                memcpy(&tmp_header, &db_in->block[curblock_in].header, sizeof(flag_gpu_input_header_t));
                 #if VERBOSE==1
-                    fprintf(stderr, "COR: Correlator is off...\n");
+    	           printf("COR: Received block %d, starting mcnt = %lld\n", curblock_in, (long long int)tmp_header.mcnt);
+                #endif
+                good_data &= tmp_header.good_data;
+                hashpipe_status_lock_safe(&st);
+                hputi4(st.buf, "CORMCNT", tmp_header.mcnt);
+                hashpipe_status_unlock_safe(&st);
+
+                // Retrieve correlator integrator status
+                hashpipe_status_lock_safe(&st);
+                hgets(st.buf, "INTSTAT", 16, integ_status);
+                hashpipe_status_unlock_safe(&st);
+        
+                // If the correlator integrator status is "off,"
+                // Free the input block and continue
+                if (strcmp(integ_status, "off") == 0) {
+                    #if VERBOSE==1
+                        fprintf(stderr, "COR: Correlator is off...\n");
+                    #endif
+                    flag_gpu_pfb_output_databuf_set_free(db_in, curblock_in);
+                    curblock_in = (curblock_in + 1) % db_in->header.n_block;
+                    good_data = 1;
+                    continue;
+                }
+
+                // If the correlator integrator status is "start,"
+                // Get the correlator started
+                // The INTSTAT string is set to "start" by the net thread once it's up and running
+                if (strcmp(integ_status, "start") == 0) {
+
+                    // Get the starting mcnt for integration (should be zero)
+                    hashpipe_status_lock_safe(&st);
+                    hgeti4(st.buf, "NETMCNT", (int *)(&start_mcnt));
+                    hashpipe_status_unlock_safe(&st); 
+
+                    // Check to see if block's starting mcnt matches INTSYNC
+                    if (db_in->block[curblock_in].header.mcnt < start_mcnt) {
+
+                        // If we get here, then there is a bug since the net thread shouldn't
+                        // mark blocks as filled that are before the starting mcnt
+                        // fprintf(stderr, "COR: Unable to start yet... waiting for mcnt = %lld\n", (long long int)start_mcnt);
+
+                        // starting mcnt not yet reached
+                        // free block and continue
+                        flag_gpu_pfb_output_databuf_set_free(db_in, curblock_in);
+                        curblock_in = (curblock_in + 1) % db_in->header.n_block;
+                        continue;
+                    }
+                    else if (db_in->block[curblock_in].header.mcnt == start_mcnt) {
+                        // set correlator integrator to "on"
+                        #if VERBOSE
+                            fprintf(stderr, "COR: Starting correlator!\n");
+                        #endif
+                        strcpy(integ_status, "on");
+                        float requested_integration_time = 0.0;
+                        float actual_integration_time = 0.0;
+                        hashpipe_status_lock_safe(&st);
+                        hputs(st.buf, "INTSTAT", integ_status);
+                        hgetr4(st.buf, "REQSTI", &requested_integration_time);
+                        hashpipe_status_unlock_safe(&st);
+
+                        int_count = ceil((N_MCNT_PER_SECOND / Nm) * requested_integration_time);
+                        actual_integration_time = int_count/(N_MCNT_PER_SECOND / Nm);
+
+                        hashpipe_status_lock_safe(&st);
+                        hputr4(st.buf, "ACTSTI", actual_integration_time);
+                        hputi4(st.buf, "INTCOUNT", int_count);
+                        hashpipe_status_unlock_safe(&st);
+
+                        // Compute last mcount
+                        last_mcnt = start_mcnt + int_count*Nm - 1;
+                    }
+                    else {
+                        // fprintf(stdout, "COR: We missed the start of the integration\n");
+                        fprintf(stdout, "COR: Missed start. Expected start_mcnt = %lld, got %lld\n", (long long int)start_mcnt, (long long int)db_in->block[curblock_in].header.mcnt);
+                        // we apparently missed the start of the integation... ouch...
+                    }
+                }
+
+                // Check to see if a stop is issued
+                if (strcmp(integ_status, "stop") == 0) {
+                    continue;
+                }
+
+                // If we get here, then integ_status == "on"
+                // Setup for current chunk
+                context.input_offset  = curblock_in  * sizeof(flag_gpu_pfb_output_block_t) / sizeof(ComplexInput);
+                context.output_offset = curblock_out * sizeof(flag_pfb_gpu_correlator_output_block_t) / sizeof(Complex);
+        
+                int doDump = 0;
+                if ((db_in->block[curblock_in].header.mcnt + Nm - 1) >= last_mcnt) {
+                    doDump = 1;
+
+                    #if VERBOSE
+                    printf("COR: Setting dump\n\t last_mcnt=%lld\n\t int_count=%d\n\t rx_mcnt=%lld\n\t Nm=%d\n",
+                                    (long long int)last_mcnt,
+                                    int_count,
+                                    (long long int)(db_in->block[curblock_in].header.mcnt),
+                                    Nm);
+                    #endif
+
+                    // Wait for new output block to be free
+                    while ((rv=flag_pfb_gpu_correlator_output_databuf_wait_free(db_out, curblock_out)) != HASHPIPE_OK) {
+                        if (rv==HASHPIPE_TIMEOUT) {
+
+                            continue;
+                        } else {
+                            hashpipe_error(__FUNCTION__, "error waiting for free databuf");
+                            // fprintf(stderr, "rv = %d\n", rv);
+                            pthread_exit(NULL);
+                            break;
+                        }
+                    }
+                }
+       
+                #if VERBOSE==1
+                    printf("COR: Running xgpuCudaXengine now...\n");
+                #endif
+                xgpuCudaXengine(&context, doDump ? SYNCOP_DUMP : SYNCOP_SYNC_TRANSFER);
+                #if VERBOSE==1
+                    printf("COR: Done!\n");
+                #endif
+           
+                #if VERBOSE==1 
+                    printf("COR: doDump = %d\n", doDump);
+                    printf("COR: start_mcnt = %lld, last_mcnt = %lld\n", (long long int)start_mcnt, (long long int)last_mcnt);
+                #endif
+
+                if (doDump) {
+                    xgpuClearDeviceIntegrationBuffer(&context);
+                    //xgpuReorderMatrix((Complex *)db_out->block[curblock_out].data);
+                    db_out->block[curblock_out].header.mcnt = start_mcnt;
+                    db_out->block[curblock_out].header.good_data = good_data;
+                    //printf("COR: Dumping correlator output with mcnt %lld\n", (long long int) start_mcnt);
+                
+                    // Mark output block as full and advance
+                    #if VERBOSE==1
+                    printf("COR: Marking output block %d as filled, mcnt=%lld\n", curblock_out, (long long int)start_mcnt);
+                    #endif
+                    flag_pfb_gpu_correlator_output_databuf_set_filled(db_out, curblock_out);
+                    curblock_out = (curblock_out + 1) % db_out->header.n_block;
+                    start_mcnt = last_mcnt + 1;
+                    last_mcnt = start_mcnt + int_count*Nm - 1;
+                    // Reset good_data flag for next block
+                    good_data = 1;
+                }
+
+                #if VERBOSE==1
+                printf("COR: Marking input block %d as free\n", curblock_in);
                 #endif
                 flag_gpu_pfb_output_databuf_set_free(db_in, curblock_in);
                 curblock_in = (curblock_in + 1) % db_in->header.n_block;
-                good_data = 1;
-                continue;
             }
-
-            // If the correlator integrator status is "start,"
-            // Get the correlator started
-            // The INTSTAT string is set to "start" by the net thread once it's up and running
-            if (strcmp(integ_status, "start") == 0) {
-
-	        // Get the starting mcnt for integration (should be zero)
-                hashpipe_status_lock_safe(&st);
-                hgeti4(st.buf, "NETMCNT", (int *)(&start_mcnt));
-                hashpipe_status_unlock_safe(&st); 
-
-                // Check to see if block's starting mcnt matches INTSYNC
-                if (db_in->block[curblock_in].header.mcnt < start_mcnt) {
-
-		    // If we get here, then there is a bug since the net thread shouldn't
-		    // mark blocks as filled that are before the starting mcnt
-                    // fprintf(stderr, "COR: Unable to start yet... waiting for mcnt = %lld\n", (long long int)start_mcnt);
-
-                    // starting mcnt not yet reached
-                    // free block and continue
-                    flag_gpu_pfb_output_databuf_set_free(db_in, curblock_in);
-                    curblock_in = (curblock_in + 1) % db_in->header.n_block;
-                    continue;
-                }
-                else if (db_in->block[curblock_in].header.mcnt == start_mcnt) {
-                    // set correlator integrator to "on"
-                    #if VERBOSE==1
-                        fprintf(stderr, "COR: Starting correlator!\n");
-                    #endif
-                    strcpy(integ_status, "on");
-                    float requested_integration_time = 0.0;
-                    float actual_integration_time = 0.0;
-                    hashpipe_status_lock_safe(&st);
-                    hputs(st.buf, "INTSTAT", integ_status);
-                    hgetr4(st.buf, "REQSTI", &requested_integration_time);
-                    hashpipe_status_unlock_safe(&st);
-
-                    int_count = ceil((N_MCNT_PER_SECOND / Nm) * requested_integration_time);
-                    actual_integration_time = int_count/(N_MCNT_PER_SECOND / Nm);
-
-                    hashpipe_status_lock_safe(&st);
-                    hputr4(st.buf, "ACTSTI", actual_integration_time);
-                    hputi4(st.buf, "INTCOUNT", int_count);
-                    hashpipe_status_unlock_safe(&st);
-
-                    // Compute last mcount
-                    last_mcnt = start_mcnt + int_count*Nm - 1;
-                }
-                else {
-                    // fprintf(stdout, "COR: We missed the start of the integration\n");
-		    fprintf(stdout, "COR: Missed start. Expected start_mcnt = %lld, got %lld\n", (long long int)start_mcnt, (long long int)db_in->block[curblock_in].header.mcnt);
-                    // we apparently missed the start of the integation... ouch...
-                }
-            }
-
-	    // Check to see if a stop is issued
-	    if (strcmp(integ_status, "stop") == 0) {
-	        continue;
-	    }
-
-            // If we get here, then integ_status == "on"
-            // Setup for current chunk
-            context.input_offset  = curblock_in  * sizeof(flag_gpu_pfb_output_block_t) / sizeof(ComplexInput);
-            context.output_offset = curblock_out * sizeof(flag_pfb_gpu_correlator_output_block_t) / sizeof(Complex);
-        
-            int doDump = 0;
-            if ((db_in->block[curblock_in].header.mcnt + int_count*Nm - 1) >= last_mcnt) {
-                doDump = 1;
-
-                // Wait for new output block to be free
-                while ((rv=flag_pfb_gpu_correlator_output_databuf_wait_free(db_out, curblock_out)) != HASHPIPE_OK) {
-                    if (rv==HASHPIPE_TIMEOUT) {
-                        /*
-                        int cleanc;
-                        hashpipe_status_lock_safe(&st);
-                        hgetl(st.buf, "CLEANC", &cleanc);
-                        hgets(st.buf, "NETSTAT", 16, netstat);
-                        hashpipe_status_unlock_safe(&st);
-                        if (cleanc == 0 && strcmp(netstat, "CLEANUP") == 0) {
-                           printf("COR: Cleanup condition met!\n");
-                           next_state = CLEANUP;
-                           break;
-                        }
-                        */
-                        continue;
-                    } else {
-                        hashpipe_error(__FUNCTION__, "error waiting for free databuf");
-                        // fprintf(stderr, "rv = %d\n", rv);
-                        pthread_exit(NULL);
-                        break;
-                    }
-                }
-            }
-       
-            #if VERBOSE==1
-                printf("COR: Running xgpuCudaXengine now...\n");
-            #endif
-            xgpuCudaXengine(&context, doDump ? SYNCOP_DUMP : SYNCOP_SYNC_TRANSFER);
-            #if VERBOSE==1
-                printf("COR: Done!\n");
-            #endif
-       
-            #if VERBOSE==1 
-                printf("COR: doDump = %d\n", doDump);
-                printf("COR: start_mcnt = %lld, last_mcnt = %lld\n", (long long int)start_mcnt, (long long int)last_mcnt);
-            #endif
-
-            if (doDump) {
-                xgpuClearDeviceIntegrationBuffer(&context);
-                //xgpuReorderMatrix((Complex *)db_out->block[curblock_out].data);
-                db_out->block[curblock_out].header.mcnt = start_mcnt;
-                db_out->block[curblock_out].header.good_data = good_data;
-                //printf("COR: Dumping correlator output with mcnt %lld\n", (long long int) start_mcnt);
-            
-
-                // Mark output block as full and advance
-                #if VERBOSE==1
-                printf("COR: Marking output block %d as filled, mcnt=%lld\n", curblock_out, (long long int)start_mcnt);
-                #endif
-                flag_pfb_gpu_correlator_output_databuf_set_filled(db_out, curblock_out);
-                curblock_out = (curblock_out + 1) % db_out->header.n_block;
-                start_mcnt = last_mcnt + 1;
-                last_mcnt = start_mcnt + int_count*Nm - 1;
-                // Reset good_data flag for next block
-                good_data = 1;
-            }
-
-            #if VERBOSE==1
-            printf("COR: Marking input block %d as free\n", curblock_in);
-            #endif
-            flag_gpu_pfb_output_databuf_set_free(db_in, curblock_in);
-            curblock_in = (curblock_in + 1) % db_in->header.n_block;
-        }
         }
         else if (cur_state == CLEANUP) {
-            printf("COR: In Cleanup\n");
-            next_state = ACQUIRE;
-            // Set interntal integ_status to start
-            hashpipe_status_lock_safe(&st);
-            hputs(st.buf, "INTSTAT", "start");
-            hashpipe_status_unlock_safe(&st);
-            strcpy(integ_status, "start");
+            //printf("COR: In Cleanup\n");
 
-            // Clear out integration buffer on GPU
-            xgpuClearDeviceIntegrationBuffer(&context);
-            curblock_in = 0;
-            curblock_out = 0;
-            //start_mcnt = 0;
-            //last_mcnt = 0;
-            good_data = 1;
             hashpipe_status_lock_safe(&st);
-            hputl(st.buf, "CLEANC", 1);
+            hgets(st.buf, "NETSTAT", 16, netstat);
             hashpipe_status_unlock_safe(&st);
+
+            if (strcmp(netstat, "IDLE") == 0) {
+                next_state = ACQUIRE;
+
+            } else {
+                next_state = CLEANUP;
+
+                // Set interntal integ_status to start
+                hashpipe_status_lock_safe(&st);
+                hputs(st.buf, "INTSTAT", "start");
+                hashpipe_status_unlock_safe(&st);
+                strcpy(integ_status, "start");
+
+                // Clear out integration buffer on GPU
+                xgpuClearDeviceIntegrationBuffer(&context);
+                curblock_in = 0;
+                curblock_out = 0;
+                //start_mcnt = 0;
+                //last_mcnt = 0;
+                good_data = 1;
+                hashpipe_status_lock_safe(&st);
+                hputl(st.buf, "CLEANC", 1);
+                hashpipe_status_unlock_safe(&st);
+            }
+            /*
+
+            int hashLocked_in = flag_gpu_pfb_output_databuf_total_status(db_in);
+            int hashLocked_out = flag_pfb_gpu_correlator_output_databuf_total_status(db_out);
+
+            printf("COR: buffer status\n\t db_in tot=%d\n\t db_out tot=%d\n\t", hashLocked_in, hashLocked_out);
+            */
+
         }
         
         // Next state processing

--- a/src/flag_pfb_thread.c
+++ b/src/flag_pfb_thread.c
@@ -73,6 +73,7 @@ static void * run(hashpipe_thread_args_t * args) {
 
     pfb_init_flag = initPFB(cudaDevice, pfbParams);
 
+
     state cur_state = ACQUIRE;
     state next_state = ACQUIRE;
     int64_t good_data = 1;
@@ -109,6 +110,13 @@ static void * run(hashpipe_thread_args_t * args) {
                     hgetl(st.buf, "CLEANB", &cleanb);
                     hgets(st.buf, "NETSTAT", 16, netstat);
                     hashpipe_status_unlock_safe(&st);
+
+
+
+
+
+
+                    
                     if (cleanb == 0 && strcmp(netstat, "CLEANUP") == 0) {
                         if(VERBOSE) {
                             printf("PFB: Cleanup detected!\n");
@@ -182,7 +190,9 @@ static void * run(hashpipe_thread_args_t * args) {
             }
         }
         else if (cur_state == CLEANUP) {
-            //printf("PFB: In Cleanup\n");
+            if (VERBOSE) {
+                printf("PFB: In Cleanup\n");
+            }
 
             hashpipe_status_lock_safe(&st);
             hgets(st.buf, "NETSTAT", 16, netstat);
@@ -190,6 +200,12 @@ static void * run(hashpipe_thread_args_t * args) {
 
             if (strcmp(netstat, "IDLE") == 0) {
                 next_state = ACQUIRE;
+                //clear output and input buffers -- make each thread clear out their output buffers.
+                //flag_databuf_clear((hashpipe_databuf_t *)db_in);
+                //flag_pfb_gpu_input_databuf_clear(db_in);
+                flag_databuf_clear((hashpipe_databuf_t *)db_out);
+                //flag_gpu_pfb_output_databuf_clear(db_out);
+                printf("PFB: Finished CLEANUP, clearing output databuf and returning to ACQUIRE\n");
             } else {
                 next_state = CLEANUP;
                 curblock_in = 0;

--- a/src/flag_pfb_transpose_thread.c
+++ b/src/flag_pfb_transpose_thread.c
@@ -156,7 +156,10 @@ static void * run(hashpipe_thread_args_t * args) {
             }
         }
         else if (cur_state == CLEANUP) {
-            //printf("TRA: In Cleanup \n");
+            
+            if (VERBOSE) {
+                printf("TRA: In Cleanup \n");
+            }
 
             hashpipe_status_lock_safe(&st);
             hgets(st.buf, "NETSTAT", 16, netstat);
@@ -164,13 +167,15 @@ static void * run(hashpipe_thread_args_t * args) {
 
             if(strcmp(netstat, "IDLE") == 0) {
                 next_state = ACQUIRE;
+                flag_databuf_clear((hashpipe_databuf_t *) db_out);
+                printf("TRA: Finished CLEANUP, clearing output databuf and returning to ACQUIRE\n");
             }
             else {
                 next_state = CLEANUP;
 
                 curblock_in = 0;
                 curblock_out = 0;
-                // Indicate that we have finished cleanup
+                // Indicate that we are cleaning up
                 hashpipe_status_lock_safe(&st);
                 hputl(st.buf, "CLEANA", 1);
                 hashpipe_status_unlock_safe(&st);


### PR DESCRIPTION
Improvements to the pipeline have been improved during the July/Aug commissioning. Improvement is measured in the decreasing number of hanging/stalling banks and bad blocks.

The FITS writer has seemed to be fixed. I can say pretty confidently there are no more memory issues with the FITS writer that would be causing issues. There was an issue that all the FITS writers were being commanded to work on the same core. This was an issue and has been fixed in the repo for the fits writer. So after these improvements to the fits writer were made I tried to tune the performance of the beamformer thread with the other threads by spreading the tasks out across the available cores. With the CPU transpose getting their own cores and the fits writer doubling up with the net thread had the best performance (at 20 input blocks). There was still significant latency. Therefore this led to the biggest change in this commit.

The major change being to the GPU beamformer library. After the above mentioned fixes were made other improvements to the beamformer were made:
There were a few memory leaks remaining from the initialization that were hanging each time a new beamformer would be initialized.
The CPU transpose has been removed and now the transpose is performed on the GPU and the subsequent flag_transpose_beamform_thread.c has been added. This has improved the performance but there is still slight tuning that needs to be done as far as tasking fits writers and threads. Data integrity of this change is currently being tested

Other improvements include:
Implementing a clear databuf method to be used at the end of each scan to guarantee freed block of semaphores and data. Each thread clears its output buffer this guarantees all databufs have been looked at.

Improvement of the clean up logic that makes each thread check to make sure the net thread has returned to idle before returning to acquire.

Packets were slipping through at the end of a scan and this has been taken care of by adding a blackhole packet. This issue is because the net thread has two cmd variables, the cmd and master_cmd variables. This is most likely redundant and was the cause of the problem as a race condition depending on if the cmd variable saw the stop before the master cmd did.

Removed frequent access of shared memory. This would slow the threads down.

Tuning of the number of input blocks. For example, the pfbcorr mode performs the best when the number of input blocks is 4 with a window size of 2. With 50 or 100 there become too many bad blocks and hanging is more frequent. This needs to be addressed and better understood.

Added a debug flag for the access of shared memory to give detailed feedback about the process of the pipeline.

General cleanup of the code and deletion of deprecated code. There have been other changes that are slipping my mind right now. To be added in comments if thought of later.
